### PR TITLE
feat: add kubectl, helm, and eksctl to clean_install.sh

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -262,8 +262,17 @@ if [ -d "$HOME/.opencode/bin" ]; then
     export PATH="$HOME/.opencode/bin:$PATH"
 fi
 
+if [ -d "$HOME/.aws" ]; then
+    [ -n "${AWS_REGION:-}" ] || export AWS_REGION="us-east-1"
+    [ -n "${AWS_DEFAULT_REGION:-}" ] || export AWS_DEFAULT_REGION="us-east-1"
+fi
+
 if command -v uv >/dev/null 2>&1; then
     eval "$(uv generate-shell-completion bash)"
+fi
+
+if command -v eksctl >/dev/null 2>&1; then
+    . <(eksctl completion bash)
 fi
 
 if [ -f "$HOME/.local/bin/env" ]; then

--- a/clean_install.sh
+++ b/clean_install.sh
@@ -395,6 +395,37 @@ else
     prn_success "Installed AWS CLI."
 fi
 
+# Install kubectl
+if command -v kubectl >/dev/null 2>&1; then
+    prn_note "kubectl already installed."
+else
+    prn_note "Installing kubectl."
+    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+    sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+    rm kubectl
+    prn_success "Installed kubectl."
+fi
+
+# Install helm
+if command -v helm >/dev/null 2>&1; then
+    prn_note "helm already installed."
+else
+    prn_note "Installing helm."
+    curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | sudo bash
+    prn_success "Installed helm."
+fi
+
+# Install eksctl
+if command -v eksctl >/dev/null 2>&1; then
+    prn_note "eksctl already installed."
+else
+    prn_note "Installing eksctl."
+    curl -LO "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz"
+    sudo tar -xzf eksctl_Linux_amd64.tar.gz -C /usr/local/bin
+    rm eksctl_Linux_amd64.tar.gz
+    prn_success "Installed eksctl."
+fi
+
 # Cleanup
 cd "$home_dir" || exit 1
 sudo rm -rf "$temp_dir"

--- a/tests/clean_install.bats
+++ b/tests/clean_install.bats
@@ -119,6 +119,30 @@ teardown_file() {
     which unzip
 }
 
+@test "integration - kubectl installation is present in clean_install.sh" {
+    run bash -c '
+        grep -Eq "(dl[.]k8s[.]io|storage[.]googleapis[.]com/kubernetes-release).*/kubectl" "$PROJECT_ROOT/clean_install.sh" &&
+        grep -Eq "(install|mv|cp|chmod).*[[:<:]]kubectl[[:>:]]" "$PROJECT_ROOT/clean_install.sh"
+    '
+    [ "$status" -eq 0 ]
+}
+
+@test "integration - helm installation is present in clean_install.sh" {
+    run bash -c '
+        grep -Eq "(raw[.]githubusercontent[.]com/helm/helm/.*/get-helm-3|get[.]helm[.]sh/helm-)" "$PROJECT_ROOT/clean_install.sh" &&
+        grep -Eq "([[:<:]]helm[[:>:]]|get-helm-3)" "$PROJECT_ROOT/clean_install.sh"
+    '
+    [ "$status" -eq 0 ]
+}
+
+@test "integration - eksctl installation is present in clean_install.sh" {
+    run bash -c '
+        grep -Eq "github[.]com/.*/eksctl/releases/.*/eksctl_" "$PROJECT_ROOT/clean_install.sh" &&
+        grep -Eq "(tar|unzip|mv|install).*[[:<:]]eksctl[[:>:]]" "$PROJECT_ROOT/clean_install.sh"
+    '
+    [ "$status" -eq 0 ]
+}
+
 @test "integration - Docker environment variables are set" {
     if [ -z "$CI" ] && [ -z "$IN_DOCKER" ]; then skip "Skipping in local unit tests"; fi
     [ -n "$CI" ] || [ -n "$IN_DOCKER" ]

--- a/tests/clean_install.bats
+++ b/tests/clean_install.bats
@@ -122,21 +122,21 @@ teardown_file() {
 @test "integration - kubectl installation is present in clean_install.sh" {
     run grep -Eq "(dl[.]k8s[.]io|storage[.]googleapis[.]com/kubernetes-release).*/kubectl" "$PROJECT_ROOT/clean_install.sh"
     [ "$status" -eq 0 ]
-    run grep -Eq "(install|mv|cp|chmod).*kubectl" "$PROJECT_ROOT/clean_install.sh"
+    run grep -Eq "(install|mv|cp|chmod).*[[:space:]/]kubectl([[:space:]]|$)" "$PROJECT_ROOT/clean_install.sh"
     [ "$status" -eq 0 ]
 }
 
 @test "integration - helm installation is present in clean_install.sh" {
     run grep -Eq "(raw[.]githubusercontent[.]com/helm/helm/.*/get-helm-3|get[.]helm[.]sh/helm-)" "$PROJECT_ROOT/clean_install.sh"
     [ "$status" -eq 0 ]
-    run grep -Eq "(helm|get-helm-3)" "$PROJECT_ROOT/clean_install.sh"
+    run grep -Eq "command -v helm" "$PROJECT_ROOT/clean_install.sh"
     [ "$status" -eq 0 ]
 }
 
 @test "integration - eksctl installation is present in clean_install.sh" {
     run grep -Eq "github[.]com/.*/eksctl/releases/.*/eksctl_" "$PROJECT_ROOT/clean_install.sh"
     [ "$status" -eq 0 ]
-    run grep -Eq "(tar|unzip|mv|install).*eksctl" "$PROJECT_ROOT/clean_install.sh"
+    run grep -Eq "(tar|unzip|mv|install).*(eksctl([[:space:]]|$)|eksctl_)" "$PROJECT_ROOT/clean_install.sh"
     [ "$status" -eq 0 ]
 }
 

--- a/tests/clean_install.bats
+++ b/tests/clean_install.bats
@@ -120,26 +120,23 @@ teardown_file() {
 }
 
 @test "integration - kubectl installation is present in clean_install.sh" {
-    run bash -c '
-        grep -Eq "(dl[.]k8s[.]io|storage[.]googleapis[.]com/kubernetes-release).*/kubectl" "$PROJECT_ROOT/clean_install.sh" &&
-        grep -Eq "(install|mv|cp|chmod).*[[:<:]]kubectl[[:>:]]" "$PROJECT_ROOT/clean_install.sh"
-    '
+    run grep -Eq "(dl[.]k8s[.]io|storage[.]googleapis[.]com/kubernetes-release).*/kubectl" "$PROJECT_ROOT/clean_install.sh"
+    [ "$status" -eq 0 ]
+    run grep -Eq "(install|mv|cp|chmod).*kubectl" "$PROJECT_ROOT/clean_install.sh"
     [ "$status" -eq 0 ]
 }
 
 @test "integration - helm installation is present in clean_install.sh" {
-    run bash -c '
-        grep -Eq "(raw[.]githubusercontent[.]com/helm/helm/.*/get-helm-3|get[.]helm[.]sh/helm-)" "$PROJECT_ROOT/clean_install.sh" &&
-        grep -Eq "([[:<:]]helm[[:>:]]|get-helm-3)" "$PROJECT_ROOT/clean_install.sh"
-    '
+    run grep -Eq "(raw[.]githubusercontent[.]com/helm/helm/.*/get-helm-3|get[.]helm[.]sh/helm-)" "$PROJECT_ROOT/clean_install.sh"
+    [ "$status" -eq 0 ]
+    run grep -Eq "(helm|get-helm-3)" "$PROJECT_ROOT/clean_install.sh"
     [ "$status" -eq 0 ]
 }
 
 @test "integration - eksctl installation is present in clean_install.sh" {
-    run bash -c '
-        grep -Eq "github[.]com/.*/eksctl/releases/.*/eksctl_" "$PROJECT_ROOT/clean_install.sh" &&
-        grep -Eq "(tar|unzip|mv|install).*[[:<:]]eksctl[[:>:]]" "$PROJECT_ROOT/clean_install.sh"
-    '
+    run grep -Eq "github[.]com/.*/eksctl/releases/.*/eksctl_" "$PROJECT_ROOT/clean_install.sh"
+    [ "$status" -eq 0 ]
+    run grep -Eq "(tar|unzip|mv|install).*eksctl" "$PROJECT_ROOT/clean_install.sh"
     [ "$status" -eq 0 ]
 }
 

--- a/tests/clean_install.bats
+++ b/tests/clean_install.bats
@@ -122,21 +122,21 @@ teardown_file() {
 @test "integration - kubectl installation is present in clean_install.sh" {
     run grep -Eq "(dl[.]k8s[.]io|storage[.]googleapis[.]com/kubernetes-release).*/kubectl" "$PROJECT_ROOT/clean_install.sh"
     [ "$status" -eq 0 ]
-    run grep -Eq "(install|mv|cp|chmod).*[[:space:]/]kubectl([[:space:]]|$)" "$PROJECT_ROOT/clean_install.sh"
+    run grep -Fq "install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl" "$PROJECT_ROOT/clean_install.sh"
     [ "$status" -eq 0 ]
 }
 
 @test "integration - helm installation is present in clean_install.sh" {
     run grep -Eq "(raw[.]githubusercontent[.]com/helm/helm/.*/get-helm-3|get[.]helm[.]sh/helm-)" "$PROJECT_ROOT/clean_install.sh"
     [ "$status" -eq 0 ]
-    run grep -Eq "command -v helm" "$PROJECT_ROOT/clean_install.sh"
+    run grep -Fq "get-helm-3 | sudo bash" "$PROJECT_ROOT/clean_install.sh"
     [ "$status" -eq 0 ]
 }
 
 @test "integration - eksctl installation is present in clean_install.sh" {
     run grep -Eq "github[.]com/.*/eksctl/releases/.*/eksctl_" "$PROJECT_ROOT/clean_install.sh"
     [ "$status" -eq 0 ]
-    run grep -Eq "(tar|unzip|mv|install).*(eksctl([[:space:]]|$)|eksctl_)" "$PROJECT_ROOT/clean_install.sh"
+    run grep -Fq "tar -xzf eksctl_Linux_amd64.tar.gz -C /usr/local/bin" "$PROJECT_ROOT/clean_install.sh"
     [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
- Install kubectl from official Kubernetes releases
- Install helm using official get-helm-3 script
- Install eksctl from GitHub releases
- Add AWS_REGION exports and eksctl completion to bashrc
- Add tests for kubectl, helm, and eksctl installation