### PR TITLE
fix(vim): auto-enable paste mode during tmux bracketed paste

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -80,6 +80,17 @@ set number	    " Show line numbers
 set ruler	    " Show ruler
 "set autoindent	    " Simple autoindentation
 set cindent	    " Smarter autoindentation - C standard
+
+function! XTermPaste(ret)
+  if a:ret
+    set paste
+  else
+    set nopaste
+  endif
+endfunction
+
+autocmd TermResponse * if v:event.response =~ '\e\[?2004h' | call XTermPaste(v:true) | endif
+autocmd CursorHoldI * if !&paste | call XTermPaste(v:false) | endif
 set hlsearch        " Highlight search results
 set incsearch       " Incremental search
 set ignorecase      " Do case insensitive matching


### PR DESCRIPTION
## Summary
- Add `TermResponse` autocmd to detect tmux bracketed paste mode (`\e[?2004h`)
- Add `CursorHoldI` fallback to disable paste mode if needed
- Prevents `cindent` from adding unwanted whitespace when pasting multi-line content

## Testing
- [x] Run `make test` (syntax + unit tests pass)
- [ ] Manual test: paste from tmux in vim insert mode, verify no extra indentation