### PR TITLE
feat: add git-cleanup function to remove local branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 SHELL := /bin/bash
 SCRIPTS := _shared_functions.sh dot_install.sh clean_install.sh bashrc bash_functions
-TEST_FILES := tests/shared_functions.bats tests/dot_install.bats tests/clean_install.bats tests/bashrc_functions.bats
+TEST_FILES := tests/shared_functions.bats tests/dot_install.bats tests/clean_install.bats tests/bashrc_functions.bats tests/git_cleanup.bats
 UBUNTU_VERSIONS := 22.04 24.04 26.04
 
 help:

--- a/bashrc
+++ b/bashrc
@@ -176,16 +176,146 @@ then
     source "$HOME/.awsenvvars.sh"
 fi
 
-# Lazy alias
-alias cvim='ctags -R . && vim .'
-
-# lazy function to unzip to folder of same name
+# unzipd: Unzips a file into a directory with the same name.
 unzipd () {
     zipfile="$1"
     zipdir=${1%%.*}
     unzip -d "$zipdir" "$zipfile"
 }
 
+# git-cleanup: Deletes local branches merged into master/main.
+# Also prunes stale remote-tracking references when remotes exist.
+# Use --aggressive to also delete non-merged branches with no unique patches.
+# Asks for confirmation before performing any destructive actions.
+git-cleanup() {
+    local aggressive=0
+    case "${1:-}" in
+        "")
+            ;;
+        -a|--aggressive)
+            aggressive=1
+            ;;
+        -h|--help)
+            printf "Usage: git-cleanup [-a|--aggressive] [-h|--help]\n"
+            printf "  -a, --aggressive  Also delete non-merged branches with no unique patches.\n"
+            printf "  -h, --help        Show this help message.\n"
+            return 0
+            ;;
+        *)
+            printf "Error: Unknown option '%s'.\n" "$1" >&2
+            printf "Usage: git-cleanup [-a|--aggressive] [-h|--help]\n" >&2
+            return 1
+            ;;
+    esac
+
+    if ! git rev-parse --git-dir >/dev/null 2>&1; then
+        printf "Error: Not inside a git repository.\n" >&2
+        return 1
+    fi
+
+    local main_branch
+    if git show-ref --verify --quiet refs/heads/main; then
+        main_branch="main"
+    elif git show-ref --verify --quiet refs/heads/master; then
+        main_branch="master"
+    else
+        printf "Error: Could not find 'main' or 'master' branch.\n" >&2
+        return 1
+    fi
+
+    printf "Using '%s' as the primary branch.\n" "$main_branch"
+
+    if [ -n "$(git remote)" ]; then
+        if ! git fetch --prune; then
+            printf "Error: Failed to prune remote-tracking references.\n" >&2
+            return 1
+        fi
+        printf "Pruned remote-tracking references.\n"
+    else
+        printf "No remotes configured; skipping remote-tracking prune.\n"
+    fi
+
+    local current_branch
+    current_branch=$(git branch --show-current)
+
+    local merged_local=()
+    local aggressive_local=()
+    local branch
+    local unique_patches
+
+    while IFS= read -r branch; do
+        [ -z "$branch" ] && continue
+        case "$branch" in
+            "$current_branch"|main|master)
+                continue
+                ;;
+        esac
+        merged_local+=("$branch")
+    done < <(git for-each-ref refs/heads --merged "$main_branch" --format='%(refname:short)')
+
+    if [ "$aggressive" -eq 1 ]; then
+        while IFS= read -r branch; do
+            [ -z "$branch" ] && continue
+            case "$branch" in
+                "$current_branch"|main|master)
+                    continue
+                    ;;
+            esac
+            if git merge-base --is-ancestor "$branch" "$main_branch"; then
+                continue
+            fi
+            unique_patches=$(git log --cherry-pick --right-only --no-merges --pretty=format:%H "$main_branch...$branch")
+            if [ -n "$unique_patches" ]; then
+                continue
+            fi
+            aggressive_local+=("$branch")
+        done < <(git for-each-ref refs/heads --format='%(refname:short)')
+    fi
+
+    if [ "${#merged_local[@]}" -eq 0 ] && [ "${#aggressive_local[@]}" -eq 0 ]; then
+        printf "No local branches to clean up.\n"
+        return 0
+    fi
+
+    if [ "${#merged_local[@]}" -ne 0 ]; then
+        printf "\nThe following merged local branches will be deleted:\n"
+        printf "%s\n" "${merged_local[@]}"
+    fi
+
+    if [ "${#aggressive_local[@]}" -ne 0 ]; then
+        printf "\nAggressive mode: the following non-merged branches have no unique patches and will be deleted:\n"
+        printf "%s\n" "${aggressive_local[@]}"
+    fi
+
+    local yn
+    printf "\n"
+    read -r -p "$(tput bold)Delete these local branches? (y/N) $(tput sgr0)" yn
+    case $yn in
+        [Yy]* )
+            local delete_failed=0
+            for branch in "${merged_local[@]}"; do
+                if ! git branch -d "$branch"; then
+                    delete_failed=1
+                fi
+            done
+            for branch in "${aggressive_local[@]}"; do
+                if ! git branch -D "$branch"; then
+                    delete_failed=1
+                fi
+            done
+            if [ "$delete_failed" -ne 0 ]; then
+                printf "Cleanup completed with errors.\n" >&2
+                return 1
+            fi
+            printf "Cleanup complete.\n"
+            ;;
+        * )
+            printf "Cleanup aborted.\n"
+            ;;
+    esac
+}
+
+# av: Activates the Python virtual environment (.venv) created by 'uv'.
 av() {
     local activate=".venv/bin/activate"
     if [ ! -f "$activate" ]; then
@@ -198,7 +328,8 @@ av() {
         "$(tput setaf 2)" "$activate" "$(tput sgr0)"
 }
 
-# Should probably just do this manually... but...
+# recurse-replace: Performs a global search and replace in the current directory using 'ack' and 'sed'.
+# Usage: recurse-replace <old_string> <new_string>
 recurse-replace () {
     old_val=$1
     new_val=$2

--- a/tests/git_cleanup.bats
+++ b/tests/git_cleanup.bats
@@ -1,0 +1,193 @@
+#!/usr/bin/env bats
+
+setup() {
+    export TEST_DIR="${BATS_TMPDIR}/git-cleanup-test-$$"
+    mkdir -p "$TEST_DIR"
+    cd "$TEST_DIR"
+    git init -b master
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    
+    echo "initial" > file
+    git add file
+    git commit -m "initial commit"
+    
+    export BASHRC_PATH="$BATS_TEST_DIRNAME/../bashrc"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+@test "git-cleanup identifies and deletes merged local branches" {
+    git checkout -b feature-merged
+    echo "feature" > feature_file
+    git add feature_file
+    git commit -m "feature commit"
+    
+    git checkout master
+    git merge feature-merged
+    
+    # Verify branch exists before cleanup
+    run git branch
+    [[ "$output" == *"feature-merged"* ]]
+    
+    # Run cleanup with "y" confirmation
+    run bash -i -c "source $BASHRC_PATH && echo y | git-cleanup"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Using 'master' as the primary branch"* ]]
+    [[ "$output" == *"feature-merged"* ]]
+    
+    # Verify branch is gone
+    run git branch
+    [[ "$output" != *"feature-merged"* ]]
+}
+
+@test "git-cleanup handles 'main' as primary branch" {
+    git branch -m master main
+    git checkout -b feature-merged
+    git commit --allow-empty -m "feature"
+    git checkout main
+    git merge feature-merged
+    
+    run bash -i -c "source $BASHRC_PATH && echo y | git-cleanup"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Using 'main' as the primary branch"* ]]
+    [[ "$output" == *"feature-merged"* ]]
+    
+    run git branch
+    [[ "$output" != *"feature-merged"* ]]
+}
+
+@test "git-cleanup does not delete the current branch" {
+    git checkout -b current-branch
+    # It is merged into master (as it is exactly at master)
+    
+    run bash -i -c "source $BASHRC_PATH && echo y | git-cleanup"
+    [ "$status" -eq 0 ]
+    
+    run git branch
+    [[ "$output" == *"* current-branch"* ]]
+}
+
+@test "git-cleanup does not delete unmerged branches" {
+    git checkout -b feature-unmerged
+    echo "unmerged" > unmerged_file
+    git add unmerged_file
+    git commit -m "unmerged commit"
+    
+    git checkout master
+    
+    run bash -i -c "source $BASHRC_PATH && echo y | git-cleanup"
+    [ "$status" -eq 0 ]
+    
+    run git branch
+    [[ "$output" == *"feature-unmerged"* ]]
+}
+
+@test "git-cleanup skips remote prune when no remotes are configured" {
+    run bash -i -c "source $BASHRC_PATH && git-cleanup"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No remotes configured; skipping remote-tracking prune."* ]]
+    [[ "$output" != *"remote-tracking references will be removed"* ]]
+}
+
+@test "git-cleanup default mode keeps non-merged patch-equivalent branches" {
+    git checkout -b feature-cherry
+    echo "shared change" >> file
+    git add file
+    git commit -m "feature change"
+
+    git checkout master
+    git commit --allow-empty -m "diverge main history"
+    git cherry-pick feature-cherry
+
+    run git branch --merged master
+    [[ "$output" != *"feature-cherry"* ]]
+
+    run bash -i -c "source $BASHRC_PATH && echo y | git-cleanup"
+    [ "$status" -eq 0 ]
+
+    run git branch
+    [[ "$output" == *"feature-cherry"* ]]
+}
+
+@test "git-cleanup --aggressive deletes non-merged patch-equivalent branches" {
+    git checkout -b feature-cherry
+    echo "shared change" >> file
+    git add file
+    git commit -m "feature change"
+
+    git checkout master
+    git commit --allow-empty -m "diverge main history"
+    git cherry-pick feature-cherry
+
+    run git branch --merged master
+    [[ "$output" != *"feature-cherry"* ]]
+
+    run bash -i -c "source $BASHRC_PATH && echo y | git-cleanup --aggressive"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Aggressive mode:"* ]]
+    [[ "$output" == *"feature-cherry"* ]]
+
+    run git branch
+    [[ "$output" != *"feature-cherry"* ]]
+}
+
+@test "git-cleanup -a deletes non-merged patch-equivalent branches" {
+    git checkout -b feature-cherry-short
+    echo "shared change short" >> file
+    git add file
+    git commit -m "feature change short"
+
+    git checkout master
+    git commit --allow-empty -m "diverge main history"
+    git cherry-pick feature-cherry-short
+
+    run git branch --merged master
+    [[ "$output" != *"feature-cherry-short"* ]]
+
+    run bash -i -c "source $BASHRC_PATH && echo y | git-cleanup -a"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Aggressive mode:"* ]]
+    [[ "$output" == *"feature-cherry-short"* ]]
+
+    run git branch
+    [[ "$output" != *"feature-cherry-short"* ]]
+}
+
+@test "git-cleanup --help prints usage" {
+    run bash -i -c "source $BASHRC_PATH && git-cleanup --help"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage: git-cleanup [-a|--aggressive] [-h|--help]"* ]]
+    [[ "$output" == *"-h, --help        Show this help message."* ]]
+}
+
+@test "git-cleanup -h prints usage" {
+    run bash -i -c "source $BASHRC_PATH && git-cleanup -h"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage: git-cleanup [-a|--aggressive] [-h|--help]"* ]]
+    [[ "$output" == *"-h, --help        Show this help message."* ]]
+}
+
+@test "git-cleanup errors outside a git repository" {
+    cd "$BATS_TMPDIR"
+
+    run bash -i -c "source $BASHRC_PATH && git-cleanup"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: Not inside a git repository."* ]]
+}
+
+@test "git-cleanup aborts on 'n' confirmation" {
+    git checkout -b feature-merged
+    git commit --allow-empty -m "feature"
+    git checkout master
+    git merge feature-merged
+    
+    run bash -i -c "source $BASHRC_PATH && echo n | git-cleanup"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Cleanup aborted."* ]]
+    
+    run git branch
+    [[ "$output" == *"feature-merged"* ]]
+}

--- a/vimrc
+++ b/vimrc
@@ -5,9 +5,8 @@ call plug#begin('~/.vim/bundle')
 Plug 'junegunn/vim-plug'
 
 Plug 'lifepillar/vim-solarized8'
-Plug 'dragfire/Improved-Syntax-Highlighting-Vim'
 Plug 'henrik/vim-indexed-search'
-Plug 'kien/rainbow_parentheses.vim'
+Plug 'luochen1990/rainbow'
 Plug 'lifepillar/vim-mucomplete'
 Plug 'scrooloose/nerdcommenter'
 Plug 'scrooloose/nerdtree'
@@ -19,15 +18,8 @@ Plug 'tpope/vim-fugitive'
 " Ruby
 Plug 'vim-ruby/vim-ruby'
 
-" Python
-Plug 'Vimjas/vim-python-pep8-indent'
-
 " Go
 Plug 'fatih/vim-go', { 'do': ':GoUpdateBinaries' }
-
-" Flutter (Dart also recommended)
-Plug 'dart-lang/dart-vim-plugin'
-Plug 'thosakwe/vim-flutter'
 
 " JavaScript
 Plug 'pangloss/vim-javascript'
@@ -39,21 +31,10 @@ Plug 'peitalin/vim-jsx-typescript'
 " SCSS
 Plug 'cakebaker/scss-syntax.vim'
 
+"""""""""""""""""""""""""""""""""""""""""""""""""""
+"""""""""""""""""""""""""""""""""""""""""""""""""""
+"""""""""""""""""""""""""""""""""""""""""""""""""""
 call plug#end()
-
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-"""""""""""""""""""""""""""""""" Github Copilot """"""""""""""""""""""""""""""""
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-" per https://github.com/github/copilot.vim
-" Installed via:
-" git clone https://github.com/github/copilot.vim \
-"   ~/.vim/pack/github/start/copilot.vim
-"
-" Disable Github Copilot
-"if exists("*Copilot")
-  "autocmd VimEnter * Copilot disable
-"endif
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 " Solarized Options
 "
@@ -79,18 +60,6 @@ set encoding=utf-8
 set number	    " Show line numbers
 set ruler	    " Show ruler
 "set autoindent	    " Simple autoindentation
-set cindent	    " Smarter autoindentation - C standard
-
-function! XTermPaste(ret)
-  if a:ret
-    set paste
-  else
-    set nopaste
-  endif
-endfunction
-
-autocmd TermResponse * if v:event.response =~ '\e\[?2004h' | call XTermPaste(v:true) | endif
-autocmd CursorHoldI * if !&paste | call XTermPaste(v:false) | endif
 set hlsearch        " Highlight search results
 set incsearch       " Incremental search
 set ignorecase      " Do case insensitive matching
@@ -119,7 +88,7 @@ set mouse=a
 
 " Allows Deletion with Backspace
 "
-set backspace=2
+set backspace=indent,eol,start
 
 " Turn Off Tool Tips in Mac/GVim
 "
@@ -142,9 +111,8 @@ let NERDTreeShowHidden=1
 "
 "set noswapfile
 set swapfile
-set dir=~/.vim_tmp,~/tmp,/var/tmp,/tmp
-set backupdir=~/.vim_tmp,~/tmp,/var/tmp,/tmp
 set directory=~/.vim_tmp,~/tmp,/var/tmp,/tmp
+set backupdir=~/.vim_tmp,~/tmp,/var/tmp,/tmp
 
 " Show Whitepace
 "
@@ -153,31 +121,36 @@ nmap <silent> <leader>s :set nolist!<CR>
 
 " Filetype Configuration
 "
+filetype plugin indent on
 syntax on
-filetype on
-filetype plugin on
-filetype indent on
-filetype detect
 
-" Powder Key Bindings
+" Language Specific Configurations
 "
-au FileType ruby,ruby-sinatra,haml,sass,html,css map <leader>p :!powder restart<cr>
-au FileType ruby,ruby-sinatra,haml,sass,html,css map <leader>o :!powder open<cr>
+augroup MyLanguageSpecific
+    autocmd!
+    " Ruby/Rails Key Bindings
+    autocmd FileType ruby,ruby-sinatra nnoremap <buffer> <leader>r :!ruby -c %<CR>
+    autocmd FileType haml nnoremap <buffer> <leader>r :!haml -c %<CR>
+    autocmd FileType sass nnoremap <buffer> <leader>r :!sass -c %<CR>
+    autocmd BufNewFile,BufRead *.hive set filetype=sql
+    autocmd BufNewFile,BufRead *.sql set filetype=sql
+    autocmd BufNewFile,BufRead *.psql set filetype=sql
+    autocmd BufNewFile,BufRead *.hamlc set ft=haml
 
-" Ruby/Rails Key Bindings
-"
-au FileType ruby,ruby-sinatra map <leader>r :!ruby -c %<cr>
-au FileType haml map <leader>r :!haml -c %<cr>
-au FileType sass map <leader>r :!sass -c %<cr>
-au BufNewFile,BufRead *.hive set filetype=sql
-au BufNewFile,BufRead *.sql set filetype=sql
-au BufNewFile,BufRead *.psql set filetype=sql
-au BufNewFile,BufRead *.hamlc set ft=haml
+    " Pig Script Syntax
+    autocmd BufNewFile,BufRead *.pig set filetype=pig syntax=pig
 
-" Pig Script Syntax
-"
-augroup filetypedetect
-  au BufNewFile,BufRead *.pig set filetype=pig syntax=pig
+    " Default spacing for Golang
+    autocmd FileType go setlocal shiftwidth=4 tabstop=4 noexpandtab
+
+    " Spacing for shell scripts
+    autocmd FileType sh setlocal shiftwidth=4 tabstop=4 expandtab
+
+    " For crontab -e to work with vim
+    autocmd filetype crontab setlocal nobackup nowritebackup
+
+    " Highlighting for systemd .service files
+    autocmd BufNewFile,BufRead *.service* set ft=systemd
 augroup END
 
 " Set 2 space tabs as default (for Ruby, etc.)
@@ -185,25 +158,6 @@ augroup END
 "
 set tabstop=2 shiftwidth=2 expandtab
 
-" Default spacing for Golang
-"
-autocmd FileType go setlocal shiftwidth=4 tabstop=4 noexpandtab
-
-" Spacing for shell scripts
-"
-autocmd FileType sh setlocal shiftwidth=4 tabstop=4 expandtab
-
-"For crontab -e to work with vim
-"
-autocmd filetype crontab setlocal nobackup nowritebackup
-
-"Highlighting for systemd .service files
-"
-autocmd BufNewFile,BufRead *.service* set ft=systemd
-
-" Tagbar Toggle
-"
-nmap <leader>t :TagbarToggle<CR>
 " Change Tab and Pane Keys
 " NOTE: C = Control, M = Option, D = Command
 "
@@ -226,15 +180,6 @@ nmap <leader>t :TagbarToggle<CR>
 "
 set clipboard=unnamedplus
 
-" Code Folding Settings
-"
-"set foldmethod=indent   "fold based on indent
-"set foldnestmax=10      "deepest fold is 10 levels
-"set nofoldenable        "dont fold by default
-"set foldlevel=1         "this is just what i use
-set nofoldenable        "disable folding
-
-
 " Highlight over 80 characters
 "
 "highlight OverLength ctermbg=red ctermfg=white guibg=#592929
@@ -252,38 +197,15 @@ hi Visual term=reverse cterm=reverse guibg=White ctermbg=White
 
 " Change cursor shape Gnome Terminal 3.x
 "
-let &t_SI = "\<Esc>[6 q"
-let &t_SR = "\<Esc>[4 q"
-let &t_EI = "\<Esc>[2 q"
+if !has('nvim')
+    let &t_SI = "\<Esc>[6 q"
+    let &t_SR = "\<Esc>[4 q"
+    let &t_EI = "\<Esc>[2 q"
+endif
 
 " Rainbow parentheses
 "
-let g:rbpt_colorpairs = [
-    \ ['brown',       'RoyalBlue3'],
-    \ ['darkred',     'DarkOrchid3'],
-    \ ['Darkblue',    'SeaGreen3'],
-    \ ['darkgreen',   'firebrick3'],
-    \ ['darkcyan',    'RoyalBlue3'],
-    \ ['darkred',     'SeaGreen3'],
-    \ ['darkmagenta', 'DarkOrchid3'],
-    \ ['brown',       'firebrick3'],
-    \ ['gray',        'RoyalBlue3'],
-    \ ['darkmagenta', 'DarkOrchid3'],
-    \ ['Darkblue',    'firebrick3'],
-    \ ['darkgreen',   'RoyalBlue3'],
-    \ ['darkcyan',    'SeaGreen3'],
-    \ ['red',         'firebrick3'],
-    \ ]
-let g:rbpt_max = 16
-let g:rbpt_loadcmd_toggle = 0
-
-au VimEnter * RainbowParenthesesToggle
-au Syntax * RainbowParenthesesLoadRound
-au Syntax * RainbowParenthesesLoadSquare
-au Syntax * RainbowParenthesesLoadBraces
-
-" Tmux conf for vim-slime
-let g:slime_target = "tmux"
+let g:rainbow_active = 1
 
 " Show trailing whitepace and spaces before a tab:
 highlight ExtraWhitespace ctermbg=red guibg=red
@@ -296,10 +218,6 @@ match ExtraWhitespace /\s\+$\| \+\ze\t/
 "
 autocmd BufWritePre * :%s/\s\+$//e
 
-"Neo Completeion with Cache for Scala autocomplete
+"For editing large data files (Vim internal default is 3000 lines)
 "
-let g:neocomplcache_enable_at_startup = 1
-
-"For editing large data files
-"
-set synmaxcol=160
+"set synmaxcol=160


### PR DESCRIPTION
delete  python-pep8-indent for now.
Rm faulty and unused vim plugins
chore(vim): clean up vimrc orphaned, redundant, and obsolete settings Use vim default for syntax on large files
feat(bash): add git-cleanup function to clean merged branches Comments for function use
fix(bash): avoid grep option misinterpretation in git-cleanup test(bash): add unit tests for git-cleanup function docs(bash): update function comments and descriptions in bashrc chore(vim): modernize and refine vimrc based on copilot suggestions chore: harden git-cleanup and vimrc mappings
Improve git-cleanup safety and messaging, expand coverage for no-remote/outside-repo paths, and use buffer-local nnoremap bindings for filetype runner mappings in vimrc. add aggressive flag to git-cleanup