### PR TITLE
feat: harden shell sync and vim performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+tmp/
+*.orig
+*.swp
+*.swo
+*~
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 SHELL := /bin/bash
 SCRIPTS := _shared_functions.sh dot_install.sh clean_install.sh bashrc bash_functions
-TEST_FILES := tests/shared_functions.bats tests/dot_install.bats tests/clean_install.bats tests/bashrc_functions.bats tests/git_cleanup.bats
+TEST_FILES := tests/shared_functions.bats tests/dot_install.bats tests/clean_install.bats tests/bashrc_functions.bats tests/git_cleanup.bats tests/systemd_sync_master.bats
 UBUNTU_VERSIONS := 22.04 24.04 26.04
 
 help:

--- a/bashrc
+++ b/bashrc
@@ -328,34 +328,63 @@ av() {
         "$(tput setaf 2)" "$activate" "$(tput sgr0)"
 }
 
-# recurse-replace: Performs a global search and replace in the current directory using 'ack' and 'sed'.
+# recurse-replace: Performs a global search and replace in the current directory using 'ack'.
 # Usage: recurse-replace <old_string> <new_string>
 recurse-replace () {
-    old_val=$1
-    new_val=$2
-    if type ack > /dev/null; then
-        color_normal=$(tput sgr0)
-        color_blue=$(tput setaf 4)
-        color_red=$(tput setaf 1)
-        color_bold=$(tput bold)
+    local old_val=${1:-}
+    local new_val=${2:-}
+    local color_normal color_blue color_red color_bold
+    color_normal=$(tput sgr0)
+    color_blue=$(tput setaf 4)
+    color_red=$(tput setaf 1)
+    color_bold=$(tput bold)
 
-        cmd="ack $old_val | grep -e '^\w' | cut -d: -f1 | xargs sed -i 's/$old_val/$new_val/g'"
-        printf "%sAbout to run:\n%s" "$color_blue" "$color_normal"
-        echo "${color_bold}$cmd${color_normal}"
-        printf "\n%sThis will replace the following:\n%s" "$color_blue" "$color_normal"
-        ack "$old_val"
-        echo
-
-        bold_message="${color_bold}Are you sure? (y/N)${color_normal}"
-        read -r -p "$bold_message" yn
-        case $yn in
-            [Yy]* ) printf "\nRunning replace command.\n"; eval "$cmd"; return 0;;
-            [Nn]* ) return 1;;
-            * ) return 1;;
-        esac
-    else
-        printf "%sERROR: 'ack' not found\n%s" "$color_red" "$color_normal"
+    if [ -z "$old_val" ] || [ -z "$new_val" ]; then
+        printf "%sUsage: recurse-replace <old_string> <new_string>%s\n" \
+            "$color_red" "$color_normal" >&2
+        return 1
     fi
+
+    if ! command -v ack >/dev/null 2>&1; then
+        printf "%sERROR: 'ack' not found%s\n" "$color_red" "$color_normal" >&2
+        return 1
+    fi
+
+    local -a files=()
+    local file
+    while IFS= read -r file; do
+        [ -n "$file" ] && files+=("$file")
+    done < <(ack -l -- "$old_val")
+
+    if [ "${#files[@]}" -eq 0 ]; then
+        printf "%sNo matches found for '%s'.%s\n" \
+            "$color_blue" "$old_val" "$color_normal"
+        return 0
+    fi
+
+    printf "%sAbout to replace '%s' with '%s' in:%s\n" \
+        "$color_blue" "$old_val" "$new_val" "$color_normal"
+    printf "%s\n" "${files[@]}"
+    printf "\n%sMatching lines:%s\n" "$color_blue" "$color_normal"
+    ack -- "$old_val"
+    echo
+
+    local yn
+    local bold_message="${color_bold}Are you sure? (y/N)${color_normal}"
+    read -r -p "$bold_message" yn
+    case $yn in
+        [Yy]* )
+            printf "\nRunning replace command.\n"
+            for file in "${files[@]}"; do
+                OLD_VAL="$old_val" NEW_VAL="$new_val" \
+                    perl -pi -e 's/\Q$ENV{OLD_VAL}\E/\Q$ENV{NEW_VAL}\E/g' -- "$file"
+            done
+            return 0
+            ;;
+        * )
+            return 1
+            ;;
+    esac
 }
 
 alias speed-test='curl -s \

--- a/systemd-sync-master.sh
+++ b/systemd-sync-master.sh
@@ -1,27 +1,49 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # To use, `sudo cp dot-files-master-sync.service /etc/systemd/system/`
 # sudo systemctl enable dot-files-master-sync.service
 # sudo systemctl start  dot-files-master-sync.service
 # sudo systemctl stop   dot-files-master-sync.service
 
-if [ ! "$(uname)" == "Linux" ]; then echo "Must be on a Linux system."; exit 1; fi
+if [ ! "$(uname)" == "Linux" ]; then
+    echo "Must be on a Linux system."
+    exit 1
+fi
 
 script_dir="$(dirname "$(readlink -f "$0")")"
 curr_dir=$PWD
+sync_interval_seconds="${SYNC_INTERVAL_SECONDS:-60}"
+sync_once="${SYNC_ONCE:-false}"
 
 while true
 do
     cd "$script_dir" || cd "$curr_dir" || exit 1
 
-    if wget -q --spider http://google.com; then
+    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        printf "Error: '%s' is not a git repository.\n" "$PWD" >&2
+    elif ! git remote get-url origin >/dev/null 2>&1; then
+        printf "Error: git remote 'origin' is not configured.\n" >&2
+    elif git ls-remote --heads origin master >/dev/null 2>&1; then
         printf "Online: "
-        git fetch
-        git reset --hard origin/master
+        if [ -n "$(git status --porcelain)" ]; then
+            printf "Local changes detected; skipping update.\n"
+        elif [ "$(git rev-parse --abbrev-ref HEAD)" != "master" ]; then
+            printf "Current branch is not 'master'; skipping update.\n"
+        elif git pull --ff-only origin master >/dev/null 2>&1; then
+            printf "Updated from origin/master.\n"
+        else
+            printf "Unable to fast-forward master; skipping update.\n"
+        fi
     else
-        printf "Offline: "
+        printf "Offline: could not reach origin/master.\n"
     fi
 
-    printf "Sleeping for 60s at: %s\n" "$(date +%H:%M:%S)"
-    sleep 60
+    if [ "$sync_once" = "true" ]; then
+        break
+    fi
+
+    printf "Sleeping for %ss at: %s\n" "$sync_interval_seconds" "$(date +%H:%M:%S)"
+    sleep "$sync_interval_seconds"
 done

--- a/tests/bashrc_functions.bats
+++ b/tests/bashrc_functions.bats
@@ -63,3 +63,69 @@ setup() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"VIRTUAL_ENV=$TEST_PROJECT/.venv"* ]]
 }
+
+@test "recurse-replace performs literal replacement after confirmation" {
+    cat > "$TEST_TMPDIR/mock-ack" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+if [ "${1:-}" = "-l" ]; then
+    shift
+fi
+if [ "${1:-}" = "--" ]; then
+    shift
+fi
+pattern=${1:-}
+if [ -z "$pattern" ]; then
+    exit 1
+fi
+grep -R --exclude-dir=.git -l -- "$pattern" .
+EOF
+    chmod +x "$TEST_TMPDIR/mock-ack"
+    mkdir -p "$TEST_TMPDIR/mockbin"
+    mv "$TEST_TMPDIR/mock-ack" "$TEST_TMPDIR/mockbin/ack"
+
+    printf "alpha1\n" > "$TEST_PROJECT/replace_target.txt"
+    run bash -i -c '
+        cd "$TEST_PROJECT"
+        export PATH="$TEST_TMPDIR/mockbin:$PATH"
+        source bashrc
+        printf "y\n" | recurse-replace "alpha1" "beta\$2"
+        cat replace_target.txt
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'beta$2'* ]]
+}
+
+@test "recurse-replace exits non-zero when canceled" {
+    cat > "$TEST_TMPDIR/mock-ack" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+if [ "${1:-}" = "-l" ]; then
+    shift
+fi
+if [ "${1:-}" = "--" ]; then
+    shift
+fi
+pattern=${1:-}
+if [ -z "$pattern" ]; then
+    exit 1
+fi
+grep -R --exclude-dir=.git -l -- "$pattern" .
+EOF
+    chmod +x "$TEST_TMPDIR/mock-ack"
+    mkdir -p "$TEST_TMPDIR/mockbin"
+    mv "$TEST_TMPDIR/mock-ack" "$TEST_TMPDIR/mockbin/ack"
+
+    printf "keepme\n" > "$TEST_PROJECT/replace_target_cancel.txt"
+    run bash -i -c '
+        cd "$TEST_PROJECT"
+        export PATH="$TEST_TMPDIR/mockbin:$PATH"
+        source bashrc
+        printf "n\n" | recurse-replace "keepme" "changed"
+        echo "status=$?"
+        cat replace_target_cancel.txt
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"status=1"* ]]
+    [[ "$output" == *"keepme"* ]]
+}

--- a/tests/clean_install.bats
+++ b/tests/clean_install.bats
@@ -181,3 +181,15 @@ teardown_file() {
     '
     [ "$status" -eq 0 ]
 }
+
+@test "vimrc scopes whitespace highlighting away from gitcommit buffers" {
+    run grep -Fq "autocmd FileType gitcommit silent! match none" "$PROJECT_ROOT/vimrc"
+    [ "$status" -eq 0 ]
+}
+
+@test "vimrc applies commit-message performance guardrails" {
+    run grep -Fq "autocmd FileType gitcommit setlocal synmaxcol=200" "$PROJECT_ROOT/vimrc"
+    [ "$status" -eq 0 ]
+    run grep -Fq "autocmd FileType gitcommit let b:rainbow_active = 0" "$PROJECT_ROOT/vimrc"
+    [ "$status" -eq 0 ]
+}

--- a/tests/systemd_sync_master.bats
+++ b/tests/systemd_sync_master.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+
+setup() {
+    export TEST_TMPDIR="${BATS_TMPDIR}/systemd-sync-test-$$"
+    mkdir -p "$TEST_TMPDIR"
+    export PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export SCRIPT_PATH="$PROJECT_ROOT/systemd-sync-master.sh"
+
+    export MOCK_BIN="$TEST_TMPDIR/mockbin"
+    mkdir -p "$MOCK_BIN"
+    export LOG_FILE="$TEST_TMPDIR/git.log"
+    : > "$LOG_FILE"
+
+    cat > "$MOCK_BIN/git" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+echo "$*" >> "${LOG_FILE:?}"
+
+if [ "$1" = "rev-parse" ] && [ "${2:-}" = "--is-inside-work-tree" ]; then
+    exit 0
+fi
+
+if [ "$1" = "remote" ] && [ "${2:-}" = "get-url" ] && [ "${3:-}" = "origin" ]; then
+    echo "git@github.com:will2357/dot-files.git"
+    exit 0
+fi
+
+if [ "$1" = "ls-remote" ] && [ "${2:-}" = "--heads" ] && [ "${3:-}" = "origin" ] && [ "${4:-}" = "master" ]; then
+    [ "${MOCK_ONLINE:-1}" = "1" ] && exit 0
+    exit 2
+fi
+
+if [ "$1" = "status" ] && [ "${2:-}" = "--porcelain" ]; then
+    printf "%s" "${MOCK_STATUS:-}"
+    exit 0
+fi
+
+if [ "$1" = "rev-parse" ] && [ "${2:-}" = "--abbrev-ref" ] && [ "${3:-}" = "HEAD" ]; then
+    echo "${MOCK_BRANCH:-master}"
+    exit 0
+fi
+
+if [ "$1" = "pull" ] && [ "${2:-}" = "--ff-only" ] && [ "${3:-}" = "origin" ] && [ "${4:-}" = "master" ]; then
+    exit "${MOCK_PULL_EXIT:-0}"
+fi
+
+exit 0
+EOF
+    chmod +x "$MOCK_BIN/git"
+}
+
+teardown() {
+    rm -rf "$TEST_TMPDIR"
+}
+
+@test "systemd sync skips update when working tree is dirty" {
+    run env \
+        PATH="$MOCK_BIN:$PATH" \
+        LOG_FILE="$LOG_FILE" \
+        MOCK_ONLINE=1 \
+        MOCK_STATUS=" M bashrc" \
+        MOCK_BRANCH=master \
+        SYNC_ONCE=true \
+        bash "$SCRIPT_PATH"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Local changes detected; skipping update."* ]]
+
+    run grep -F "pull --ff-only origin master" "$LOG_FILE"
+    [ "$status" -ne 0 ]
+}
+
+@test "systemd sync fast-forwards master when clean" {
+    run env \
+        PATH="$MOCK_BIN:$PATH" \
+        LOG_FILE="$LOG_FILE" \
+        MOCK_ONLINE=1 \
+        MOCK_STATUS="" \
+        MOCK_BRANCH=master \
+        MOCK_PULL_EXIT=0 \
+        SYNC_ONCE=true \
+        bash "$SCRIPT_PATH"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Updated from origin/master."* ]]
+
+    run grep -F "pull --ff-only origin master" "$LOG_FILE"
+    [ "$status" -eq 0 ]
+}
+
+@test "systemd sync skips update when branch is not master" {
+    run env \
+        PATH="$MOCK_BIN:$PATH" \
+        LOG_FILE="$LOG_FILE" \
+        MOCK_ONLINE=1 \
+        MOCK_STATUS="" \
+        MOCK_BRANCH=feature-branch \
+        SYNC_ONCE=true \
+        bash "$SCRIPT_PATH"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Current branch is not 'master'; skipping update."* ]]
+
+    run grep -F "pull --ff-only origin master" "$LOG_FILE"
+    [ "$status" -ne 0 ]
+}

--- a/vimrc
+++ b/vimrc
@@ -209,16 +209,21 @@ let g:rainbow_active = 1
 
 " Show trailing whitepace and spaces before a tab:
 highlight ExtraWhitespace ctermbg=red guibg=red
-match ExtraWhitespace /\s\+$\| \+\ze\t/
+augroup MyWhitespaceHighlights
+    autocmd!
+    autocmd BufEnter * if &filetype !=# 'gitcommit' | match ExtraWhitespace /\s\+$\| \+\ze\t/ | endif
+    autocmd FileType gitcommit silent! match none
+    autocmd BufWritePre * if &filetype !=# 'gitcommit' | %s/\s\+$//e | endif
+augroup END
 "highlight ExtraWhitespace ctermbg=darkgreen guibg=lightgreen
 "highlight ExtraWhitespace ctermbg=darkgreen guibg=darkgreen
 
 
-"Automatically remove trailing whitespace
-"
-autocmd BufWritePre * :%s/\s\+$//e
+" Performance safeguards for commit-message buffers
+augroup MyGitCommitPerformance
+    autocmd!
+    autocmd FileType gitcommit setlocal synmaxcol=200
+    autocmd FileType gitcommit let b:rainbow_active = 0
+augroup END
 
-" For editing large data files
-set synmaxcol=500
-set maxmempattern=2000
-set redrawtime=2000
+" Keep Vim global defaults for maxmempattern/redrawtime to avoid global regressions.


### PR DESCRIPTION
Refactor recurse-replace to avoid eval, harden systemd sync behavior, scope expensive vim highlighting away from gitcommit buffers, and add behavior-focused Bats coverage.

chore: add repository gitignore

Ignore tmp and common editor/backup artifacts to reduce repository clutter.