### PR TITLE
fix(install): harden server detection and isolate logic

### DIFF
--- a/_shared_functions.sh
+++ b/_shared_functions.sh
@@ -54,3 +54,5 @@ get_input () {
         fi
     done
 }
+
+source "${BASH_SOURCE%/*}/is_server.sh"

--- a/clean_install.sh
+++ b/clean_install.sh
@@ -71,13 +71,7 @@ sudo apt install -y ack \
 prn_success "Installed basic packages via apt."
 
 # Detect if we are on a desktop or server
-if dpkg -l ubuntu-desktop 2>/dev/null | grep -q '^ii' || \
-   dpkg -l ubuntu-desktop-minimal 2>/dev/null | grep -q '^ii' || \
-   [ "$(systemctl get-default 2>/dev/null)" == "graphical.target" ]; then
-    server="false"
-else
-    server="true"
-fi
+server=$(is_server)
 
 if [ "$server" != "true"  ]
 then

--- a/is_server.sh
+++ b/is_server.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+is_server () {
+    local verbose=${1:-false}
+    local server="true"
+
+    if [ "$verbose" = "true" ]; then echo "Starting server detection..."; fi
+
+    if dpkg -l ubuntu-desktop 2>/dev/null | grep -q '^ii' || \
+       dpkg -l ubuntu-desktop-minimal 2>/dev/null | grep -q '^ii'; then
+        if [ "$verbose" = "true" ]; then echo "Desktop packages found via dpkg."; fi
+        server="false"
+    elif [ "$(systemctl get-default 2>/dev/null)" = "graphical.target" ]; then
+        if [ "$verbose" = "true" ]; then echo "Systemd target is 'graphical.target'. Checking for display managers..."; fi
+        # If the target is graphical, verify if a display manager is actually installed
+        if dpkg -l gdm3 2>/dev/null | grep -q '^ii' || \
+           dpkg -l lightdm 2>/dev/null | grep -q '^ii' || \
+           dpkg -l sddm 2>/dev/null | grep -q '^ii'; then
+            if [ "$verbose" = "true" ]; then echo "Display manager found."; fi
+            server="false"
+        else
+            if [ "$verbose" = "true" ]; then echo "No display manager found despite graphical target."; fi
+        fi
+    fi
+
+    # Final check: if hostnamectl explicitly reports 'server' chassis, trust it
+    local chassis
+    chassis=$(hostnamectl status 2>/dev/null | grep "Chassis:" | awk '{print $2}')
+    if [ "$chassis" = "server" ]; then
+        if [ "$verbose" = "true" ]; then echo "hostnamectl reports 'server' chassis. Overriding result to server=true."; fi
+        server="true"
+    elif [ "$verbose" = "true" ] && [ -n "$chassis" ]; then
+        echo "hostnamectl reports chassis: $chassis"
+    fi
+
+    if [ "$verbose" = "true" ]; then echo "Final detection result: server=$server"; fi
+    echo "$server"
+}
+
+# If the script is run directly (not sourced), run the detection with verbose output
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    is_server true
+fi

--- a/tests/server_detection.bats
+++ b/tests/server_detection.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+
+setup() {
+    source "./_shared_functions.sh"
+}
+
+# Mocking functions
+dpkg() {
+    if [[ "$*" == "-l ubuntu-desktop" ]] && [[ "${MOCK_DESKTOP_INSTALLED:-}" == "true" ]]; then
+        echo "ii  ubuntu-desktop"
+        return 0
+    fi
+    if [[ "$*" == "-l ubuntu-desktop-minimal" ]] && [[ "${MOCK_DESKTOP_MINIMAL_INSTALLED:-}" == "true" ]]; then
+        echo "ii  ubuntu-desktop-minimal"
+        return 0
+    fi
+    if [[ "$*" == "-l gdm3" ]] && [[ "${MOCK_GDM3_INSTALLED:-}" == "true" ]]; then
+        echo "ii  gdm3"
+        return 0
+    fi
+    return 1
+}
+
+systemctl() {
+    if [[ "$*" == "get-default" ]]; then
+        echo "${MOCK_TARGET:-multi-user.target}"
+        return 0
+    fi
+    return 1
+}
+
+hostnamectl() {
+    if [[ "$*" == "status" ]]; then
+        echo "Chassis: ${MOCK_CHASSIS:-vm}"
+        return 0
+    fi
+    return 1
+}
+
+export -f dpkg systemctl hostnamectl
+
+@test "is_server - returns true for default (multi-user.target, no desktop pkgs)" {
+    export MOCK_TARGET="multi-user.target"
+    export MOCK_DESKTOP_INSTALLED="false"
+    export MOCK_DESKTOP_MINIMAL_INSTALLED="false"
+    export MOCK_CHASSIS="vm"
+    
+    run is_server
+    [ "$output" = "true" ]
+}
+
+@test "is_server - returns false if ubuntu-desktop is installed" {
+    export MOCK_TARGET="multi-user.target"
+    export MOCK_DESKTOP_INSTALLED="true"
+    
+    run is_server
+    [ "$output" = "false" ]
+}
+
+@test "is_server - returns false if ubuntu-desktop-minimal is installed" {
+    export MOCK_DESKTOP_MINIMAL_INSTALLED="true"
+    
+    run is_server
+    [ "$output" = "false" ]
+}
+
+@test "is_server - returns false if target is graphical and gdm3 is installed" {
+    export MOCK_TARGET="graphical.target"
+    export MOCK_GDM3_INSTALLED="true"
+    
+    run is_server
+    [ "$output" = "false" ]
+}
+
+@test "is_server - returns true if target is graphical but no display manager or desktop pkgs" {
+    export MOCK_TARGET="graphical.target"
+    export MOCK_DESKTOP_INSTALLED="false"
+    export MOCK_GDM3_INSTALLED="false"
+    
+    run is_server
+    [ "$output" = "true" ]
+}
+
+@test "is_server - returns true if chassis is server (even if graphical target is set)" {
+    export MOCK_TARGET="graphical.target"
+    export MOCK_GDM3_INSTALLED="true"
+    export MOCK_CHASSIS="server"
+    
+    run is_server
+    [ "$output" = "true" ]
+}


### PR DESCRIPTION
- Move server detection to a standalone, testable 'is_server.sh' script.
- Add robust checks for display managers and 'hostnamectl' chassis type.
- Add comprehensive unit tests for various environment simulations.